### PR TITLE
fix(coloros-note): 修正 rich_notes INSERT 列值与列数不匹配

### DIFF
--- a/app/src/io/github/okaidev/pickupcode/NotesBackend.java
+++ b/app/src/io/github/okaidev/pickupcode/NotesBackend.java
@@ -158,7 +158,7 @@ public class NotesBackend {
                     + " 'color_skin_white', 'color_skin_white', 0, 0,"
                     + " '{\"encryptStatus\":-1,\"featureList\":[],\"moveOutFromPaintFolder\":0,\"pageResults\":[]}',"
                     + " 0, 1, 0, NULL, NULL, NULL, 0, 0, NULL, '[]',"
-                    + " '" + t + "', '" + esc + "', '', '', '[]', 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, '', '', 0, 0);\n";
+                    + " '" + t + "', '" + esc + "', '', '', '[]', 0, 0, 0, 0, 0, 0, 0, 0, 3, '', '', 0, 0);\n";
         }
         if (BACKEND_COLOROS_TODO.equals(b)) {
             // 日历待办：字段约定来自日历 App 亲手建的两条样本（无提醒快捷待办）


### PR DESCRIPTION
## 问题

`NotesBackend.insertSqlOf()` 的 **coloros_note** 分支中，`rich_notes` 的 INSERT 列出了 47 个列名，但 VALUES 提供了 **48 个值**（末尾多了一个 `0`）。SQLite 因列数/值数不匹配直接报错，而该错误在 `TodoWriter` 的 su 执行封装里被归类为「全部 su 路径失败」，导致排查方向被误导（看起来像 root/su 问题）。

## 复现

- 环境：一加 9 Pro（LE2120）/ ColorOS 16 / Android 16 / KernelSU + LSPosed，v2.7.0
- 设置页「写入目标」切到「ColorOS 便签 置顶笔记」→ 点「🧪 一键测试」→ 失败，提示“全部 su 路径失败”

## 证据

- 以 root 用同一 SQL 直写 `/data/user/0/com.coloros.note/databases/nearme_note.db` → 报列值与列数不匹配
- 去掉多余的 `0` 后执行 → `INSERT_OK`，便签 App 中可见新笔记且已置顶

## 修改

```diff
- " '" + t + "', '" + esc + "', '', '', '[]', 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, '', '', 0, 0);
";
+ " '" + t + "', '" + esc + "', '', '', '[]', 0, 0, 0, 0, 0, 0, 0, 0, 3, '', '', 0, 0);
";
```

即 `summary_attachment` 之后应为 8 个 `0`（summary_attachment_size、summary_speech_flag、summary_speech_type、summary_show_icon、summary_note_type_flag、is_cover_paint_not_char_count、is_summary_edit、is_paint_pic）再接 `3`（summary_version）。

## 影响

v2.7.0 的 ColorOS 便签后端（备用目标）完全不可用；日历待办后端不受影响。

已在真机（一加 9 Pro / ColorOS 16）验证修复后写入成功。